### PR TITLE
Mod that handles negatives

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ emptySector = new Uint8Array(emptySectorBuffer);
 
 sizeDelta = 0;
 
-function mod (num, n) { return ( num < 0 ? (num % n) + n : num % n) }
+function mod (num, n) { return ((num % n) + n) % n }
 
 function Region(buffer, x, z) {
   var i, nSectors, offset, sectorNum;


### PR DESCRIPTION
Found the issue with negative region coordinates in blockplot:

``` js
function mod (num, n) { return ( num < 0 ? (num % n) + n : num % n) }
console.log(mod(-32, 32)); // === 32

function mod (num, n) { return ((num % n) + n) % n }
console.log(mod2(-32, 32)); // === 0
```

So `r.0.-1.mca` would start counting at `32` and be instantly out of range.
