### PR TITLE
update jDataView to the same version minecraft-nbt uses

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var dataview = require('jDataView');
+var dataview = require('jdataview');
 var NBTReader = require('minecraft-nbt').NBTReader;
 var chunk = require('minecraft-chunk');
 if (process.browser) var Zlib = require('./zlib-inflate.min').Zlib

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "author": "Jason Livesay <ithkuil@gmail.com>, Max Ogden <max@maxogden.com>",
   "license": "BSD",
   "dependencies": {
-    "minecraft-chunk": "0.3.0",
-    "jDataView": "~1.1.0",
-    "minecraft-nbt": "0.0.2"
+    "minecraft-chunk": "0.3.1",
+    "jdataview": "^2.2.5",
+    "minecraft-nbt": "0.0.3"
   }
 }


### PR DESCRIPTION
needed because it triggers an npm error on node >=4
